### PR TITLE
FIX - realign online signature on last proposal page when extra PDFs

### DIFF
--- a/htdocs/concatpdf/class/actions_concatpdf.class.php
+++ b/htdocs/concatpdf/class/actions_concatpdf.class.php
@@ -400,6 +400,79 @@ class ActionsConcatPdf
 	}
 
 	/**
+	 * Hook AddSignature (context 'onlinesign').
+	 *
+	 * When extra PDFs (typically T&Cs) have been concatenated after the proposal
+	 * PDF by this module, the online signature placement falls on the last page
+	 * of the final PDF — i.e. the last appended document — instead of the
+	 * signature box on the proposal itself.
+	 *
+	 * This handler counts the appended pages and sets PROPAL_SIGNATURE_ON_SPECIFIC_PAGE
+	 * to a negative value (= count from end), so the standard signature flow
+	 * places the stamp on the last page of the proposal. Returns 0 to keep the
+	 * default flow running with the corrected target page.
+	 *
+	 * No-op when nothing has been concatenated, when the object is not a
+	 * proposal, when the mixed (interleaved) concatenation mode is enabled, or
+	 * when the appended documents are dynamic templates whose page count cannot
+	 * be determined without regeneration.
+	 *
+	 * @param   array   $parameters     Hook parameters ('sourcefile', 'newpdffilename')
+	 * @param   object  $object         Signed object (Propal expected)
+	 * @param   string  $action         Current action
+	 * @return  int                     0 = continue default, <0 = KO, >0 = replace default
+	 */
+	public function AddSignature($parameters, &$object, &$action)
+	{
+		global $conf;
+
+		if (!is_object($object) || $object->element !== 'propal') {
+			return 0;
+		}
+		if (empty($object->extraparams['concatpdf']) || !is_array($object->extraparams['concatpdf'])) {
+			return 0;
+		}
+		// Mixed mode interleaves proposal/T&C pages, so "count from end" no longer
+		// matches the last proposal page. Bail out and rely on legacy placement.
+		if (getDolGlobalString('CONCATPDF_MIXED_CONCATENATION_ENABLED')) {
+			dol_syslog(get_class($this).'::AddSignature mixed concatenation enabled, skipping signature realignment', LOG_INFO);
+			return 0;
+		}
+
+		$appendedPages = 0;
+		$reader = pdf_getInstance();
+
+		foreach ($object->extraparams['concatpdf'] as $concatfile) {
+			if ($concatfile === '' || $concatfile === '-1') {
+				continue;
+			}
+			// Dynamic templates would need to be regenerated to be counted; bail out
+			// and let the legacy "last page" placement apply rather than guess wrong.
+			if (preg_match('/^pdf_(.*)+\.modules/', $concatfile)) {
+				dol_syslog(get_class($this).'::AddSignature dynamic concat template "'.$concatfile.'" not measurable, skipping signature realignment', LOG_WARNING);
+				return 0;
+			}
+			$appendedFile = $conf->concatpdf->dir_output.'/proposals/'.$concatfile.(preg_match('/\.pdf$/i', $concatfile) ? '' : '.pdf');
+			if (!dol_is_file($appendedFile)) {
+				dol_syslog(get_class($this).'::AddSignature appended file not found "'.$appendedFile.'"', LOG_WARNING);
+				continue;
+			}
+			$pages = $reader->setSourceFile($appendedFile);
+			if ($pages > 0) {
+				$appendedPages += $pages;
+			}
+		}
+
+		if ($appendedPages > 0) {
+			// Negative value = count from end. Last proposal page = pagecount - appendedPages.
+			$conf->global->PROPAL_SIGNATURE_ON_SPECIFIC_PAGE = -$appendedPages;
+			dol_syslog(get_class($this).'::AddSignature realigning online signature, target page set to -'.$appendedPages);
+		}
+
+		return 0;
+	}
+
+	/**
 	 * Concat PDF files
 	 *
 	 * @param 	PDF		$pdf    Pdf

--- a/htdocs/concatpdf/core/modules/modConcatPdf.class.php
+++ b/htdocs/concatpdf/core/modules/modConcatPdf.class.php
@@ -73,7 +73,7 @@ class modConcatPdf extends DolibarrModules
 				//						'barcode' => 0,                                  // Set this to 1 if module has its own barcode directory
 				//						'models' => 0,                                   // Set this to 1 if module has its own models directory
 				//						'css' => '/filemanager/css/concatpdf.css.php',   // Set this to relative path of css if module has its own css file
-										'hooks' => array('invoicecard','propalcard','ordercard','invoicesuppliercard','ordersuppliercard','supplier_proposalcard','contractcard','pdfgeneration')  // Set here all hooks context managed by module
+										'hooks' => array('invoicecard','propalcard','ordercard','invoicesuppliercard','ordersuppliercard','supplier_proposalcard','contractcard','pdfgeneration','onlinesign')  // Set here all hooks context managed by module
 		);
 
 		// Data directories to create when module is enabled


### PR DESCRIPTION
Add: support for the AddSignature hook (context onlinesign)                                                                                                                                                                     

 The Dolibarr core exposes, through the AddSignature hook in the onlinesign context, an extension point that lets modules adjust or fully replace the placement of the online signature on the generated PDF (see                
htdocs/core/ajax/onlineSign.php, propal branch). 

Use case: when ConcatPDF appends one or more PDFs (T&Cs, annexes, …) after the proposal PDF, last_main_doc points to the concatenated file. The online signature flow computes its position from the last imported page, so when annexes have been added the signature lands on the last annex page instead of the signature box defined by the proposal's PDF template.

Relationship with existing pdfExtractMetadata / PAGESIGN= logic (introduced in 6.0.4 for Dolibarr v22+): the metadata-based path correctly handles setups where the proposal PDF model embeds the PAGESIGN= keyword in its metadata. This hook acts as a deterministic fallback that doesn't depend on the PDF model: it derives the target page directly from extraparams['concatpdf'], so it covers custom or third-party PDF models that don't carry PAGESIGN=, as well as Dolibarr versions where pdfExtractMetadata() is unavailable. 

Implementation: this patch registers the module on the onlinesign context and implements AddSignature as follows:
   1. read the list of appended PDFs from extraparams['concatpdf'] (already persisted by afterPDFCreation);
   2. count the number of appended pages by reading each annex via setSourceFile;                                                                                                                                                  
   3. set PROPAL_SIGNATURE_ON_SPECIFIC_PAGE to -N (negative values are officially supported and mean "count from the end"), so the signature falls back onto the last page of the native proposal;                                 
   4. return 0 to keep the default flow running with the corrected target page. 
    
   Backward compatibility: on Dolibarr versions where the onlinesign context is not fired by the core, the hook simply stays dormant — no existing execution path is altered. Current behavior is preserved as-is when no annex has been concatenated. 
No other module/object is impacted: the contract and fichinter branches of the signature flow are out of scope.